### PR TITLE
Adds puppet version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ gem install r10k-resolve
 1. Run `r10k-resolve` from the same directory to generate the `Puppetfile` with
    all dependencies resolved.
      - You can also pass `--source` and `--output` arguments if you'd rather.
+     - If you're not running the current version of Puppet, specify it with `--puppet-version`.
 1. Review the generated `Puppetfile` for quality and security purposes. This is
    optional, but highly recommended.
 1. Commit the `Puppetfile` and deploy your control repository, as fitting your

--- a/bin/r10k-resolve
+++ b/bin/r10k-resolve
@@ -26,6 +26,9 @@ OptionParser.new do |opts|
   opts.on("-o", "--output [FILE]", "Pass the name of an output file (Puppetfile)") do |v|
     options[:output] = v
   end
+  opts.on("-p", "--puppet-version [VERSION]", "Pass the version number of Puppet to constrain to. Default is latest.") do |v|
+    options[:puppetversion] = v
+  end
   opts.on("-f", "--[no-]force", "Overwrite an existing output file") do |v|
     options[:force] = v
   end
@@ -52,4 +55,13 @@ else
   end
 end
 
-R10kResolve.new(options).resolve
+begin
+  R10kResolve.new(options).resolve
+rescue StandardError => e
+  case logger.level
+  when Logger::DEBUG
+    puts e.full_message
+  else
+    puts "#{e.class}: #{e.message}"
+  end
+end

--- a/lib/r10k-resolve.rb
+++ b/lib/r10k-resolve.rb
@@ -3,10 +3,10 @@ require "puppetfile-resolver"
 require "puppetfile-resolver/puppetfile/parser/r10k_eval"
 
 class R10kResolve
-  attr_accessor :source, :output, :force, :dryrun, :logger
+  attr_accessor :source, :output, :puppetversion, :force, :dryrun, :logger
 
   def initialize(options = {})
-    [:source, :output, :force, :dryrun, :logger].each do |key|
+    [:source, :output, :puppetversion, :force, :dryrun, :logger].each do |key|
       send("#{key}=", options[key])
     end
 
@@ -24,7 +24,7 @@ class R10kResolve
       return false
     end
 
-    resolver = PuppetfileResolver::Resolver.new(puppetfile, nil)
+    resolver = PuppetfileResolver::Resolver.new(puppetfile, puppetversion)
     result = resolver.resolve(strict_mode: true)
 
     # Output resolution validation information
@@ -46,7 +46,9 @@ class R10kResolve
       @output.write("mod '#{dep.payload.owner}-#{dep.payload.name}', '#{dep.payload.version}'\n")
     end
 
-    @output.write("\n# Generated with r10k-resolve version #{R10kResolve::VERSION}\n\n")
+    @output.write("\n# Generated with r10k-resolve v#{R10kResolve::VERSION}")
+    @output.write(" for Puppet v#{puppetversion}") if puppetversion
+    @output.write("\n\n")
 
     logger.warn(
       "Please inspect the output to ensure you know what you are deploying in your infrastructure."


### PR DESCRIPTION
This allows one to specify a version of Puppet to constrain to. Since
this makes it more likely for dependencies to not resolve, it also adds
a little bit of error handling for usability.
